### PR TITLE
Update xcframework paths for XCode 14.3

### DIFF
--- a/curl_ios_static.xcodeproj/project.pbxproj
+++ b/curl_ios_static.xcodeproj/project.pbxproj
@@ -715,10 +715,10 @@
 		2219E2691FD7E58600675252 /* tool_xattr.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tool_xattr.c; sourceTree = "<group>"; };
 		2219E26A1FD7E58600675252 /* tool_xattr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tool_xattr.h; sourceTree = "<group>"; };
 		D224184C26EA0BD10078E35E /* BlinkConfig.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BlinkConfig.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D271F98525B5B7DF005F88E5 /* openssl.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = openssl.xcframework; path = xcfs/.build/artifacts/xcfs/openssl.xcframework; sourceTree = "<group>"; };
-		D271F98625B5B7DF005F88E5 /* libssh2.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = libssh2.xcframework; path = xcfs/.build/artifacts/xcfs/libssh2.xcframework; sourceTree = "<group>"; };
-		D2D492BB25CD81D0007659F1 /* libssh2.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = libssh2.xcframework; path = ../../xcfs/.build/artifacts/xcfs/libssh2.xcframework; sourceTree = "<group>"; };
-		D2D492BF25CD81EA007659F1 /* openssl.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = openssl.xcframework; path = ../../xcfs/.build/artifacts/xcfs/openssl.xcframework; sourceTree = "<group>"; };
+		D271F98525B5B7DF005F88E5 /* openssl.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = openssl.xcframework; path = xcfs/.build/artifacts/xcfs/openssl/openssl.xcframework; sourceTree = "<group>"; };
+		D271F98625B5B7DF005F88E5 /* libssh2.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = libssh2.xcframework; path = xcfs/.build/artifacts/xcfs/libssh2/libssh2.xcframework; sourceTree = "<group>"; };
+		D2D492BB25CD81D0007659F1 /* libssh2.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = libssh2.xcframework; path = ../../xcfs/.build/artifacts/xcfs/libssh2/libssh2.xcframework; sourceTree = "<group>"; };
+		D2D492BF25CD81EA007659F1 /* openssl.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = openssl.xcframework; path = ../../xcfs/.build/artifacts/xcfs/openssl/openssl.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */


### PR DESCRIPTION
The latest XCode / swift package manager changes the locations of artifacts, this change points to their new default location.